### PR TITLE
1UL(unsigned long)を1ull(unsigned long long)に修正

### DIFF
--- a/RollingHash.cpp
+++ b/RollingHash.cpp
@@ -3,15 +3,15 @@ struct rolling_hash {
     int n;
 
     using ull = unsigned long long;
-    static constexpr ull MOD = (1UL << 61) - 1;
+    static constexpr ull MOD = (1ull << 61) - 1;
     // static constexpr int base = 9973;
     static inline const ull base = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();;
     std::vector<ull> hash, power;
 
     // a*b mod 2^61-1 (最後にModを取らない) / note: result < 4*MOD
     static ull mul(ull a, ull b) {
-        static constexpr ull MASK30 = (1UL << 30) - 1;
-        static constexpr ull MASK31 = (1UL << 31) - 1;
+        static constexpr ull MASK30 = (1ull << 30) - 1;
+        static constexpr ull MASK31 = (1ull << 31) - 1;
         ull au = a >> 31;
         ull ad = a & MASK31;
         ull bu = b >> 31;


### PR DESCRIPTION
Codeforces の問題でローリングハッシュ部分でコンパイルエラーが出たため、修正版をプルリクエストさせていただきます。

`1UL` は unsigned long 型でコンパイルエラーが出ていたため、`1ull` の unsigned long long 型に修正しました。

修正前の提出 : https://codeforces.com/contest/1800/submission/215692551
修正後の提出 : https://codeforces.com/contest/1800/submission/215693476